### PR TITLE
fix: don't push forward if vehicle is locked

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -120,6 +120,7 @@ local function startMove(netid, direction, pedid)
     while remotepush do
         Wait(0)
         if GetVehicleDoorLockStatus(vehicle) > 1 then return end
+	if GetPedInVehicleSeat(vehicle, -1) > 0 then return end
         if IsEntityInAir(vehicle) or IsEntityUpsidedown(vehicle) or IsEntityAttachedToAnyVehicle(remoteped) == false then
             remotepush = false
             return TriggerServerEvent('OT_pushvehicle:detach', netid)

--- a/client/main.lua
+++ b/client/main.lua
@@ -120,7 +120,7 @@ local function startMove(netid, direction, pedid)
     while remotepush do
         Wait(0)
         if GetVehicleDoorLockStatus(vehicle) > 1 then return end
-	if GetPedInVehicleSeat(vehicle, -1) > 0 then return end
+        if GetPedInVehicleSeat(vehicle, -1) > 0 then return end
         if IsEntityInAir(vehicle) or IsEntityUpsidedown(vehicle) or IsEntityAttachedToAnyVehicle(remoteped) == false then
             remotepush = false
             return TriggerServerEvent('OT_pushvehicle:detach', netid)

--- a/client/main.lua
+++ b/client/main.lua
@@ -119,6 +119,7 @@ local function startMove(netid, direction, pedid)
     remotepush = true
     while remotepush do
         Wait(0)
+        if GetVehicleDoorLockStatus(vehicle) > 1 then return end
         if IsEntityInAir(vehicle) or IsEntityUpsidedown(vehicle) or IsEntityAttachedToAnyVehicle(remoteped) == false then
             remotepush = false
             return TriggerServerEvent('OT_pushvehicle:detach', netid)


### PR DESCRIPTION
If locked / handbraked don't perform push forward, but allow animation.

Fix for #5 

also don't push if driver seat is not empty.

> in most scenarios we won't want to allow that, people pushing your car over the cliffs and so on, i think it's a good idea to have this disabled too