### PR TITLE
Add Icon and reword target push text

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -244,7 +244,8 @@ if Config.target then
 	local options = {
 		{
 			name = 'startPushing',
-			label = 'Start Pushing',
+			icon = "fa-solid fa-truck-arrow-right",
+			label = 'Push Vehicle',
 			onSelect = function(data)
 				startPushing(data.entity)
 			end,


### PR DESCRIPTION
Added an icon (truck with an arrow on it) to give the target an icon to match most other target menu options. Felt a bit naked without it. Also changed the text a bit to make it a little more clear.

![image](https://github.com/OTSTUDIOS/OT_pushvehicle/assets/85725579/151fb198-913e-46cb-a275-5254671e4cf1)
